### PR TITLE
Address <> in URI introduced by PyGithub

### DIFF
--- a/src/onto_crawler/api.py
+++ b/src/onto_crawler/api.py
@@ -93,7 +93,13 @@ def _extract_info_from_issue_object(issue: Issue) -> dict:
 
 
 def _make_sense_of_body(body: str) -> list:
-    return body.replace("\r", "").replace("\n", "").split("* ")[1:]
+    return (
+        body.replace("\r", "")
+        .replace("\n", "")
+        .replace("<", "")
+        .replace(">", "")
+        .split("* ")[1:]
+    )
 
 
 def get_all_labels_from_repo(repository_name: str) -> dict:

--- a/src/onto_crawler/cli.py
+++ b/src/onto_crawler/cli.py
@@ -49,6 +49,7 @@ input_argument = click.argument("input", required=True, type=click.Path())
 repo_option = click.option(
     "-r",
     "--repo",
+    required=True,
     help="Org/name of the github repo.",
 )
 


### PR DESCRIPTION
Apparently when an issue is read by `PyGithub`, urls are enclosed in `<>` automatically. Addresses that in this PR.